### PR TITLE
Hiding the stereo and depth camera to save computation

### DIFF
--- a/ADF/segmentation_camera.yaml
+++ b/ADF/segmentation_camera.yaml
@@ -19,6 +19,7 @@ segmentation_camera:
   parent: main_camera
   # multipass: true
   publish image: true
+  visible: False
   preprocessing shaders:
     path: ./shaders/preprocessing/
     vertex: shader.vs

--- a/ADF/stereo_cameras.yaml
+++ b/ADF/stereo_cameras.yaml
@@ -18,6 +18,7 @@ stereoL:
   monitor: 0
   # multipass: true
   publish image: true
+  visible: False
   # preprocessing shaders:
   #   path: ../../../ambf_shaders/preprocessing/
   #   vertex: shader.vs
@@ -44,6 +45,7 @@ stereoR:
   monitor: 0
   # multipass: true
   publish image: true
+  visible: False
   # preprocessing shaders:
   #   path: ../../../ambf_shaders/preprocessing/
   #   vertex: shader.vs


### PR DESCRIPTION
Newer features in AMBF allow for the hiding of a camera and allow for its video or depth to be published. This saves a rendering pass and computational resources.